### PR TITLE
#5 feat: add block status (pending/orphan/valid)

### DIFF
--- a/views/search_block.pug
+++ b/views/search_block.pug
@@ -22,6 +22,14 @@ block content
           div.card.p-3.bg-light.mb-2
             div Hash: #{hash}
           div.card.p-3.bg-light.mb-2
+            div Status:&nbsp;
+              if result.orphan_status
+                span.badge.bg-danger Orphan
+              else if result.depth > -10
+                span.badge.bg-warning.text-dark Pending
+              else
+                span.badge.bg-success Valid
+          div.card.p-3.bg-light.mb-2
             div Previous block hash:
               a(href=`/search/${result.block.header.previous_block_hash}`) #{result.block.header.previous_block_hash}
           div.card.p-3.bg-light.mb-2


### PR DESCRIPTION
This commit contains new row on block page. It shows block status. Can be pending or orphan or valid.
Please double-check before merge, because if I get it right `result.depth` must increment by moving through the chain, but on my local machine just last 6 blocks was pending...