### PR TITLE
Add search by "height_or_depth", update block-num

### DIFF
--- a/routes/search.js
+++ b/routes/search.js
@@ -8,7 +8,12 @@ router.get('/:hash', async function (req, res, next) {
     let item;
     const {hash} = req.params;
     try {
-        item = await rpc('get_raw_block', {hash});
+        item = await rpc(
+            'get_raw_block', 
+                (hash.length === 64)            //if hash
+                    ? {hash}	                //get_raw_block by "block_hash" in first parameter. 
+                    : {"height_or_depth": hash}	//or get_raw_block by height_or_depth (positive "block_number" or negative "depth")
+        );
         if (item && item.result) {
             if (item.result.block && item.result.block.header.timestamp) {
                 item.result.block.header.timestamp = item.result.block.header.timestamp.toString() + ' - ' + timeDifference(item.result.block.header.timestamp);

--- a/views/index.pug
+++ b/views/index.pug
@@ -5,12 +5,13 @@ block content
     div.container.mb-4.mt-4
       div.row.mb-3
         div.col
-          img.logo(src='/images/logo-black.svg')
-          h1 Armor block explorer
+          a(href=`/`)
+            img.logo(src='/images/logo-black.svg')
+            h1 Armor block explorer
       form#search
         div.row
           div.col
-            input#hash.form-control(type='text' name='hash' placeholder='Insert block or transaction hash')
+            input#hash.form-control(type='text' name='hash' placeholder='Insert block or transaction hash, or positive block-number (height) or negative depth-number.')
           div.col-auto
             button.btn.btn-primary(type='submit') Search
 

--- a/views/search_block.pug
+++ b/views/search_block.pug
@@ -5,12 +5,13 @@ block content
     div.container.mb-4.mt-4
       div.row.mb-3
         div.col
-          img.logo(src='/images/logo-black.svg')
-          h1 Armor block explorer
+          a(href=`/`)
+            img.logo(src='/images/logo-black.svg')
+            h1 Armor block explorer
       form#search
         div.row
           div.col
-            input#hash.form-control(type='text' name='hash' placeholder='Insert block or transaction hash' value=`${hash}`)
+            input#hash.form-control(type='text' name='hash' placeholder='Insert block or transaction hash, or positive block-number (height) or negative depth-number.' value=`${hash}`)
           div.col-auto
             button.btn.btn-primary(type='submit') Search
 
@@ -20,7 +21,9 @@ block content
         div.col-6
           h3 Found block:
           div.card.p-3.bg-light.mb-2
-            div Hash: #{hash}
+            div Block number: #{result.block.header.height}
+          div.card.p-3.bg-light.mb-2
+            div Hash: #{result.block.header.hash}
           div.card.p-3.bg-light.mb-2
             div Status:&nbsp;
               if result.orphan_status

--- a/views/search_transaction.pug
+++ b/views/search_transaction.pug
@@ -5,12 +5,13 @@ block content
     div.container.mb-4.mt-4
       div.row.mb-3
         div.col
-          img.logo(src='/images/logo-black.svg')
-          h1 Armor block explorer
+          a(href=`/`)
+            img.logo(src='/images/logo-black.svg')
+            h1 Armor block explorer
       form#search
         div.row
           div.col
-            input#hash.form-control(type='text' name='hash' placeholder='Insert block or transaction hash' value=`${hash}`)
+            input#hash.form-control(type='text' name='hash' placeholder='Insert block or transaction hash, or positive block-number (height) or negative depth-number.' value=`${hash}`)
           div.col-auto
             button.btn.btn-primary(type='submit') Search
 


### PR DESCRIPTION
+ `routes/search.js`
    `Hash` can be `height_or_depth` too, not only `block_hash` or `transaction_hash`.
    This allow to `get_raw_block` by `block_hash`, or by `height` (`positive number`), or by `depth` (`negative number`).
    This values can be inputed in search field.

+ `views/index.pug`
   `views/search_transaction.pug`
    Use link to back to the `index`-page.
    Update text in `placeholder`, for search input.

 + `views/layout.pug`
Add metatags, according this `Pull-Request`: https://github.com/armornetworkdev/armor-explorer/pull/6/files

 + `views/search_block.pug`
    The same changes as 2.
    Fix correct value of `block_hash` at line `26`, and add block_number at line `24`.